### PR TITLE
added combine reducers

### DIFF
--- a/reducers/index.js
+++ b/reducers/index.js
@@ -1,0 +1,6 @@
+import { combineReducers } from 'redux'
+import PostReducer from './PostReducer'
+
+export default combineReducers({
+  PostReducer
+})

--- a/store.js
+++ b/store.js
@@ -1,7 +1,7 @@
 import { createStore, applyMiddleware } from 'redux'
 import { composeWithDevTools } from 'redux-devtools-extension'
 import thunkMiddleware from 'redux-thunk'
-import { PostReducer } from './reducers/PostReducer';
+import reducer from './reducers/index';
 
 export const initialState = {
   posts: [],
@@ -9,5 +9,5 @@ export const initialState = {
 };
 
 export const initStore = (initialState = initialState) => {
-  return createStore(PostReducer, initialState, composeWithDevTools(applyMiddleware(thunkMiddleware)))
+  return createStore(reducer, initialState, composeWithDevTools(applyMiddleware(thunkMiddleware)))
 };


### PR DESCRIPTION
Hey Nick, take a look at these changes, they ultimately break the build. Even with a work around that might look something like this:

```
export default function reducer(state = {}, action) {
  return {
    PostReducer: PostReducer(state.PostReducer, action),
  }
}
```